### PR TITLE
Replace today with min checkin

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -1,7 +1,3 @@
-(function () {
-    'use strict'
-
-    exports.Klass = require('./src/PeriodOfStayInput')
-    exports.Model = require('./src/Model')
-    exports.Environment = require('./src/Environment')
-}())
+exports.Klass = require('./src/PeriodOfStayInput')
+exports.Model = require('./src/Model')
+exports.Environment = require('./src/Environment')

--- a/index.js
+++ b/index.js
@@ -1,8 +1,4 @@
-(function () {
-    'use strict'
-
-    exports.Klass = require('./src/PeriodOfStayInput')
-    exports.Model = require('./src/Model')
-    exports.Environment = require('./src/Environment')
-    exports.intlMessages = require('./src/intlMessages')
-}())
+exports.Klass = require('./src/PeriodOfStayInput')
+exports.Model = require('./src/Model')
+exports.Environment = require('./src/Environment')
+exports.intlMessages = require('./src/intlMessages')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-period-of-stay-input",
-  "version": "5.0.3",
+  "version": "6.0.0-0",
   "description": "React.js component for entering a period of stay in a hotel: check-in + check-out date",
   "main": "index.js",
   "browser": "browser.js",

--- a/src/Environment.js
+++ b/src/Environment.js
@@ -1,8 +1,4 @@
-(function () {
-    'use strict'
-
-    module.exports = function (zeroNightsAllowed, today) {
-        this.zeroNightsAllowed = zeroNightsAllowed
-        this.today = today
-    }
-}())
+module.exports = function (zeroNightsAllowed, minCheckInDate) {
+    this.zeroNightsAllowed = zeroNightsAllowed
+    this.minCheckInDate = minCheckInDate
+}

--- a/src/Model.js
+++ b/src/Model.js
@@ -25,7 +25,7 @@ Model.prototype.newCheckIn = function (checkInDate, environment) {
     const mCheckOut = moment(this.checkOutDate, fmt())
     const mCheckIn = moment(checkInDate, fmt())
 
-    if (mCheckIn.isBefore(moment(environment.today, fmt()))) {
+    if (mCheckIn.isBefore(moment(environment.minCheckInDate, fmt()))) {
         return this
     }
 
@@ -39,16 +39,16 @@ Model.prototype.newCheckIn = function (checkInDate, environment) {
 Model.prototype.newCheckOut = function (checkOutDate, environment) {
     const mCheckIn = moment(this.checkInDate, fmt())
     const mCheckOut = moment(checkOutDate, fmt())
-    const mToday = moment(environment.today, fmt())
+    const mMinCheckInDate = moment(environment.minCheckInDate, fmt())
 
     if (
-        mCheckOut.isBefore(mToday) ||
-        (!environment.zeroNightsAllowed && mCheckOut.isSame(mToday, 'day'))
+        mCheckOut.isBefore(mMinCheckInDate) ||
+        (!environment.zeroNightsAllowed && mCheckOut.isSame(mMinCheckInDate, 'day'))
     ) {
         return this
     }
 
-    if (environment.zeroNightsAllowed && mCheckOut.isSame(mToday, 'day')) {
+    if (environment.zeroNightsAllowed && mCheckOut.isSame(mMinCheckInDate, 'day')) {
         return new Model(checkOutDate, checkOutDate)
     }
 

--- a/src/intlMessages.js
+++ b/src/intlMessages.js
@@ -1,23 +1,19 @@
-(function () {
-    'use strict'
+module.exports = function () {
+    return {
+        en: {
+            'react-period-of-stay-input': {
+                period: '{count, plural, =0 {Single day} =1 {1 night} other {# nights}}',
+                checkInDay: 'Check-in day',
+                checkOutDay: 'Check-out day'
+            }
+        },
 
-    module.exports = function () {
-        return {
-            en: {
-                'react-period-of-stay-input': {
-                    period: '{count, plural, =0 {Single day} =1 {1 night} other {# nights}}',
-                    checkInDay: 'Check-in day',
-                    checkOutDay: 'Check-out day'
-                }
-            },
-
-            de: {
-                'react-period-of-stay-input': {
-                    'period': '{count, plural, =0 {Ein Tag} =1 {1 Nacht} other {# Nächte}}',
-                    'checkInDay': 'Anreise',
-                    'checkOutDay': 'Abreise'
-                }
+        de: {
+            'react-period-of-stay-input': {
+                'period': '{count, plural, =0 {Ein Tag} =1 {1 Nacht} other {# Nächte}}',
+                'checkInDay': 'Anreise',
+                'checkOutDay': 'Abreise'
             }
         }
     }
-}())
+}

--- a/tests/Environment.spec.js
+++ b/tests/Environment.spec.js
@@ -5,6 +5,6 @@ describe('Environment', function () {
     it('is just a record constructor', function () {
         var env = new Environment(true, '2014-09-24')
         assert.strictEqual(env.zeroNightsAllowed, true)
-        assert.strictEqual(env.today, '2014-09-24')
+        assert.strictEqual(env.minCheckInDate, '2014-09-24')
     })
 })

--- a/tests/Model.spec.js
+++ b/tests/Model.spec.js
@@ -47,7 +47,7 @@ describe('Model', function () {
                     assertValue(m.newCheckIn('2014-09-30', e), '2014-09-30', '2014-09-30')
                 })
 
-                it('reverts the change if the value is before today', function () {
+                it('reverts the change if the value is before min checkout', function () {
                     assertValue(m.newCheckIn('2014-09-23', e), '2014-09-24', '2014-09-30')
                 })
             })
@@ -87,7 +87,7 @@ describe('Model', function () {
                     assertValue(m.newCheckOut('2014-09-24', e), '2014-09-23', '2014-09-24')
                 })
 
-                it('reject the change if the new value is today', function () {
+                it('reject the change if the new value is minCheckInDate', function () {
                     assertValue(m.newCheckOut('2014-09-20', e), '2014-09-24', '2014-09-30')
                 })
             })
@@ -101,7 +101,7 @@ describe('Model', function () {
                 })
             })
 
-            describe('when it\'s today and zero nights are allowed', function () {
+            describe('when it\'s minCheckInDate and zero nights are allowed', function () {
                 const m = new Model('2014-09-24', '2014-09-30')
                 const e = new Environment(true, '2014-09-24')
 
@@ -113,7 +113,7 @@ describe('Model', function () {
                     assertValue(m.newCheckOut('2014-09-01', e), '2014-09-24', '2014-09-30')
                 })
 
-                it('yields a single-day stay if the value is today', function () {
+                it('yields a single-day stay if the value is minCheckInDate', function () {
                     assertValue(m.newCheckOut('2014-09-24', e), '2014-09-24', '2014-09-24')
                 })
             })


### PR DESCRIPTION
Re https://trello.com/c/0IGmEUpR/116-search-a-date-for-yesterday-today-11h

One of our customers need to book the rooms for yesterday—today. That happens in the night from 00:00:00 to 04:59:59. Thus, we can't call it "today" anymore.